### PR TITLE
김진홍 4일차 문제 풀이 (40분 초과)

### DIFF
--- a/Level 1/Week01/Day4/kjh1.kt
+++ b/Level 1/Week01/Day4/kjh1.kt
@@ -1,0 +1,33 @@
+import java.util.*;
+
+class Solution {
+    fun solution(board: Array<IntArray>, moves: IntArray): Int {
+        val sections = Array<Stack<Int>>(board[0].size) { Stack<Int>() }
+        
+        for (secIdx in 0..board[0].size-1) {
+            for (i in board.size-1 downTo 0) {
+                val doll = board[i][secIdx]
+                if (doll == 0) break
+                sections[secIdx].push(doll)
+            }
+        }
+        
+        var goneDolls = 0
+        
+        val basket = Stack<Int>()
+        for (move in moves) {
+            val secIdx = move-1
+            if (sections[secIdx].isEmpty()) continue
+            
+            val pickedDoll = sections[secIdx].pop()
+            if (!basket.isEmpty() && basket.peek() == pickedDoll) {
+                basket.pop()
+                goneDolls += 2
+                continue
+            }
+            basket.push(pickedDoll)
+        }
+        
+        return goneDolls
+    }
+}

--- a/Level 1/Week01/Day4/kjh2.kt
+++ b/Level 1/Week01/Day4/kjh2.kt
@@ -1,0 +1,48 @@
+class Solution {
+  fun solution(sizes: Array<IntArray>): Int {
+      val widthMax = sizes.map { it[0] }.maxOrNull()!!
+      val heightMax = sizes.map { it[1] }.maxOrNull()!!
+      
+      println("$widthMax $heightMax")
+      
+      if (widthMax > heightMax) {
+          var allFit = true
+          
+          for (h in 0..heightMax) {
+              allFit = true
+              for (size in sizes) {
+                  val fit = (size[0] <= h && size[1] <= widthMax)
+                      || (size[0] <= widthMax && size[1] <= h)
+                  if (!fit) {
+                      allFit = false
+                      break
+                  }
+              }
+              
+              if (allFit) {
+                  return h * widthMax
+              }
+          }
+      }
+      
+      for (w in 0..widthMax) {
+          var allFit = true
+          
+          for (size in sizes) {
+              allFit = true
+              val fit = (size[0] <= w && size[1] <= heightMax)
+                  || (size[0] <= heightMax && size[1] <= w)
+              if (!fit) {
+                  allFit = false
+                  break
+              }
+          }
+          
+          if (allFit) {
+              return w * heightMax
+          }
+      }
+      
+      return 0
+  }
+}

--- a/Level 1/Week01/README.md
+++ b/Level 1/Week01/README.md
@@ -72,7 +72,7 @@
 | 1   | [크레인 인형뽑기 게임](https://school.programmers.co.kr/learn/courses/30/lessons/64061) |
 | 2   | [최소직사각형](https://school.programmers.co.kr/learn/courses/30/lessons/86491)         |
 
-| **진홍** | 문제1 답안 | 문제2 답안 |
+| **진홍** | [문제1 답안](Day4/kjh1.kt) | [문제2 답안](Day4/kjh2.kt) |
 | ------ | ---------- | ---------- |
 
 | **현수** | 문제1 답안 | 문제2 답안 |


### PR DESCRIPTION
### 총 걸린시간

<!-- 네이버 시계 등 캡쳐 필수! -->
<img width="799" alt="image" src="https://user-images.githubusercontent.com/33937365/223997616-8db78f5c-f6a6-43ee-b2f7-06b22efed27f.png">
2번 문제 푸는 도중 시간 초과!
약 3분 정도 더 써서 결국 풀어내긴했다.

# 문제1

## 채점 결과
<img width="550" alt="image" src="https://user-images.githubusercontent.com/33937365/223997735-96ae4ea0-1a42-4143-9530-ba0b7a36cd1b.png">

## 로직에 대한 직관적인 설명

각 열별로 Stack을 구성한 Stack배열을 만들어두고

moves 배열을 순회하며
해당 열에서 인형을 뽑아다가 basket에 담는다

basket에 담을 것이 bakset의 가장 위에 있는 것과 동일하다면
넣지 않고 오히려 빼면서 2를 카운팅해둔다

카운팅한 수를 반환한다

## 복잡도

_N=가로 M=세로_
시간복잡도 O(NM)
공간복잡도 O(NM)

# 문제2

## 채점 결과
<img width="550" alt="image" src="https://user-images.githubusercontent.com/33937365/223997767-e45d9820-0dbe-428a-b43e-3e1ceed64d4c.png">

## 로직에 대한 직관적인 설명

가로 최대 크기와 세로 최대 크기를 구하고

그중 더 큰 쪽 크기를 고정해놓고

반대쪽 크기에 대해
i=(0부터 반대쪽 최대크기까지) 순회한다
모든 지갑을 수납가능한 i가 나오면 해당 i와 고정한 크기를 곱한 값을 반환한다

## 이 문제를 실패한 사람에게 꿀팁을 준다면?
가로 최대 크기, 세로 최대 크기 중
더 큰 최대 크기 하나는 고정이다!

80x50
70x50
70x70

이렇게 있다치면
각각 80, 70, 70이 최대 크기로 있는건 고정이란거다

이 점을 이용해서 나머지 한쪽 크기에 대해서만 완전탐색을 하면 된다

## 복잡도

_N=지갑의 수, M=가로 세로 최대크기 중 더 큰 값_
시간복잡도 O(NM)
공간복잡도 O(N)

# 소감

와.. Level 1 만만하게 봤는데.. 40분 안에 못 풀어버렸다

이렇게까지 시간이 걸린 요인은
1. 로직을 생각해내느라 (특히 2번)
2. 디버깅하느라
3. 여유롭게 하느라

이 두 가지 이유가 큰 것 같다.

반성하자면

1
급해도 로직을 먼저 생각한 뒤에 코딩하자.
검증하지도 않은 로직으로 코딩해봤자 다 날리는 수가 있다.

2
좀 더 신중하고 꼼꼼하게 디버깅하자.
빨리빨리 한다고 대강 디버깅하다가 오히려 시간 더 날렸다.

3
실전처럼 긴장감 좀 갖자.
완전 실전처럼은 무리겠지만 너무 여유롭게 한 감이 있다.