### PR TITLE
김진홍 29일차 문제 풀이

### DIFF
--- a/Level 2/Week05/Day29/kjh1.kt
+++ b/Level 2/Week05/Day29/kjh1.kt
@@ -1,0 +1,76 @@
+// 맨해튼 거리 = |y2-y1|+|x2-x1|
+// 거리두기 위반 = 맨해튼 거리 2 이하, 사이에 파티션 없음
+// 거리두기 위반 사례 나열
+    // 상하좌우
+    // 2칸 상하좌우, 파티션 없음
+    // 대각선, 파티션 2개 미만
+// 파티션을 벽으로 취급하고, 두 응시자 사이의 거리가 2 이하인게 있다면 위반
+// 플로이드 와샬
+
+class Solution {
+  fun solution(places: Array<Array<String>>): IntArray {
+      val answer = IntArray(places.size)
+      
+      for ((idx, place) in places.withIndex()) {
+          answer[idx] = if (hasViolation(place)) 0 else 1
+      }
+      
+      return answer
+  }
+  
+  fun hasViolation(place: Array<String>): Boolean {
+      val distance = initDistance(place)
+      
+      for (via in 0..24) {
+          for (from in 0..24) {
+              for (to in 0..24) {
+                  val shortcut = distance[from][via] + distance[via][to]
+                  if (shortcut < distance[from][to]) {
+                      distance[from][to] = shortcut
+                  }
+              }
+          }
+      }
+      
+      for (from in 0..24) {
+          for (to in from+1..24) {
+              val isExaminee = place[from/5][from%5] == 'P' && place[to/5][to%5] == 'P'
+              if (!isExaminee) continue
+              
+              if (distance[from][to] <= 2) return true
+          }
+      }
+      
+      return false
+  }
+  
+  fun initDistance(place: Array<String>): Array<IntArray> {
+      val distance = Array(25) { IntArray(25) { 100 } }
+      
+      val dy = arrayOf(0, 0, -1, 1)
+      val dx = arrayOf(-1, 1, 0, 0)
+      for (y in 0..4) {
+          for (x in 0..4) {
+              if (place[y][x] == 'X') continue
+              
+              val fromIdx = y*5+x
+              distance[fromIdx][fromIdx] = 0
+              
+              for (d in 0..3) {
+                  val aroundY = y + dy[d]
+                  val aroundX = x + dx[d]
+                  
+                  val outOfIndex = aroundY < 0 || aroundX < 0 || aroundY >= 5 || aroundX >= 5
+                  if (outOfIndex) continue
+                  
+                  if (place[aroundY][aroundX] == 'X') continue
+                  
+                  val toIdx = aroundY * 5 + aroundX
+                  distance[fromIdx][toIdx] = 1
+              }
+          }
+      }
+      
+      return distance
+  }
+}

--- a/Level 2/Week05/Day29/kjh2.kt
+++ b/Level 2/Week05/Day29/kjh2.kt
@@ -1,0 +1,26 @@
+// 던전 = 최소 필요 피로도, 소모 피로 필요도를 가짐 [최소, 소모]
+// 최대한 많은 던전을 도는 수
+
+// 완전탐색
+// 중복불가 순열
+import kotlin.math.max
+
+class Solution {
+    fun solution(k: Int, dungeons: Array<IntArray>): Int {
+        var maxExps = 0
+        
+        fun updateMaxExps(currentK: Int = k, availableDungeons: List<IntArray> = dungeons.toList(), exps: Int = 0) {
+            for (dungeon in availableDungeons) {
+                val (required, consumed) = dungeon
+                if (currentK < required) continue
+                
+                updateMaxExps(currentK-consumed, availableDungeons-dungeon, exps+1)
+            }
+            
+            maxExps = max(exps, maxExps)
+        }
+        updateMaxExps()
+        
+        return maxExps
+    }
+}

--- a/Level 2/Week05/README.md
+++ b/Level 2/Week05/README.md
@@ -9,7 +9,7 @@
 | 1   | [거리두기 확인하기](https://school.programmers.co.kr/learn/courses/30/lessons/81302) |
 | 2   | [피로도](https://school.programmers.co.kr/learn/courses/30/lessons/87946) |
 
-| **진홍** | 문제1 답안 | 문제2 답안 |
+| **진홍** | [문제1 답안](Day29/kjh1.kt) | [문제2 답안](Day29/kjh2.kt) |
 | ------ | ---------- | ---------- |
 
 | **현수** | 문제1 답안 | 문제2 답안 |


### PR DESCRIPTION
### 총 걸린시간

<!-- 네이버 시계 등 캡쳐 필수! -->
<img width="451" alt="SCR-20230403-slxk" src="https://user-images.githubusercontent.com/33937365/229507197-67cf869c-c30d-4cf1-8172-8df1db85a78e.png">
약 40분 걸렸음 (TinyStopWatch라는 맥 앱스토어 앱인데 좋네요)

# 문제1

## 채점 결과
<img width="489" alt="SCR-20230403-slwd" src="https://user-images.githubusercontent.com/33937365/229507302-98c0ff2b-e3b3-437a-a3f5-c56dc9eac428.png">

## 로직에 대한 직관적인 설명

문제의 핵심
* 파티션 = 갈 수 없는 노드로 취급했을때, 임의의 응시자와 응시자 사이의 최단거리가 2이하인게 하나라도 있다면 위반

풀이 방법
1. 각 대기실마다 플로이드 와샬로 모든 노드에서 모든 노드로 가는 모든 최단거리를 구한다
2. 응시자 노드에서 응시자 노드로 가는 최단거리가 2 이하인게 하나라도 있다면 위반, 없다면 준수로 본다

## 이 문제를 실패한 사람에게 꿀팁을 준다면?

플로이드 와샬이라는 노드와 노드사이의 모든 최단거리를 구하는 O(N^3)짜리 알고리즘이 있습니다
이 알고리즘을 공부해보시면 좋을 것 같습니다

## 복잡도

시간복잡도 O(N^3)
공간복잡도 O(N^2)

# 문제2

## 채점 결과
<img width="522" alt="SCR-20230403-slwt" src="https://user-images.githubusercontent.com/33937365/229507328-e3154a4e-882f-4f8d-9c97-f052c4040cf0.png">

## 로직에 대한 직관적인 설명

문제의 핵심
* 중복없는 순열 브루트포스

풀이 방법
* (현재 피로도, 갈 수 있는 던전들, 클리어한 던전 수)의 매개변수를 가지는 재귀함수를 만들었습니다
* 최소 필요 피로도를 감안해 갈 수 있는 던전에 대해 재귀호출하여 모두 가고,
* 갈 수 있는 던전을 모두 갔다면 '클리어한 던전 수'를 이용해 maxExps라는 최대 던전 방문횟수를 갱신합니다

## 이 문제를 실패한 사람에게 꿀팁을 준다면?
<!-- 적고싶은 게 없다면 삭제해도 됨 -->
순열, 조합 완전탐색 쪽을 공부해보시면 좋을 것 같습니다

## 복잡도

시간복잡도 O(N!)
공간복잡도 O(N!) : 콜 스택

# 소감

접해봤던 유형의 문제가 나와서 잘 풀 수 있었던 것 같다.

플로이드 와샬의 경우 알고리즘 구현 방법을 까먹어서 따로 검색해야 했었다.
그래서 바로 해보는 플로이드 와샬 복습
1. 주어진 간선을 이용해 각 정점에서 딱 한번만 이동했을때의 거리 값으로 distance[i][j] 배열을 초기화해둔다 (갈 수 없는 경우 최대값+1 이상으로)
2. 출발지-경유지-목적지 3중 for문으로 [출발지][경유지]+[경유지][목적지]가 [출발지][목적지]보다 작다면 distance를 갱신한다